### PR TITLE
Support directory navigation in TRAMP, also use cl-lib instead of cl

### DIFF
--- a/shell-here.el
+++ b/shell-here.el
@@ -51,7 +51,7 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (defvar shell-here-project-root-functions
   '(projectile-project-root ffip-project-root)
@@ -141,6 +141,7 @@ root."
       ;; We need to `cd'
       (when (not (string= (shell-here-stripslash
                            (expand-file-name default-directory)) target))
+        (setq target (substring target (string-match "[^\:]+\/[^\:\*\\\<\>\|]+" target)))
 
         ;; Save any input on the command line; `comint-kill-input'
         ;; calls `kill-region', which we have flet with a function
@@ -148,13 +149,12 @@ root."
         ;; The (insert (prog1 …)) inserts it (or an empty string, if
         ;; we know we have a new buffer) back into the shell buffer
         ;; after having changed directories.
-        (flet ((kill-region (start end)
+        (cl-flet ((kill-region (start end)
                  (prog1
                      (buffer-substring start end) (delete-region start end))))
           (insert (prog1 (or (when (not new) (comint-kill-input)) "")
                     (insert (concat "cd " (shell-quote-argument target)))
-                    (comint-send-input)
-                    (shell-cd target))))))))
+                    (comint-send-input))))))))
 
 (provide 'shell-here)
 ;;; shell-here.el ends here

--- a/shell-here.el
+++ b/shell-here.el
@@ -141,7 +141,9 @@ root."
       ;; We need to `cd'
       (when (not (string= (shell-here-stripslash
                            (expand-file-name default-directory)) target))
-        (setq target (substring target (string-match "[^\:]+\/[^\:\*\\\<\>\|]+" target)))
+        (when (tramp-tramp-file-p target)
+          (with-parsed-tramp-file-name target path
+            (setq target path-localname)))
 
         ;; Save any input on the command line; `comint-kill-input'
         ;; calls `kill-region', which we have flet with a function


### PR DESCRIPTION
Without that regex, it will try `cd /ssh:foo:/dir/dir2`, which is an invalid `cd` command.

Also, use `cl-lib` instead of `cl` because the latter is obsolete.